### PR TITLE
Instruct users to install straight from GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ Read and process constituency trees in various formats.
 ## Install:
 * From GitHub:
 ```bash
-git clone https://github.com/sebpuetz/lumberjack
-cd lumberjack
-cargo install --path . 
+cargo install --git https://github.com/sebpuetz/lumberjack
 ```
 
 ## Usage as standalone:


### PR DESCRIPTION
Maybe you knew this, but `cargo` can install crates directly from GitHub, no `git clone` required. It's one line installation, plus users can upgrade with `cargo install --force --git https://github.com/sebpuetz/lumberjack`. Your choice, though!